### PR TITLE
Oneteam 339 - Specify, walk through, and mandate our (initial) build, tag, and deploy strategy.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text eol=lf

--- a/openshift/build.yaml
+++ b/openshift/build.yaml
@@ -43,14 +43,14 @@ objects:
     creationTimestamp: null
     labels:
       build: ${NAME}
-    name: ${NAME}${SUFFIX}
+    name: ${NAME}-${VERSION}${SUFFIX}
   spec:
     nodeSelector: null
     runPolicy: SerialLatestOnly
     output:
       to:
         kind: ImageStreamTag
-        name: ${NAME}:${TOMCAT_VERSION}${IMAGE_TAG_SUFFIX}
+        name: ${NAME}:${VERSION}${SUFFIX}
     postCommit: {}
     resources: {}
     source:
@@ -76,18 +76,20 @@ parameters:
 - description: Name used for all created objects
   displayName: Name
   name: NAME
-  required: true
   value: ha-tomcat9
-- description: A suffix appended to all objects
-  name: SUFFIX
-  value: -build
+  required: true
 - name: TOMCAT_VERSION
   value: "9.0.27"
-- name: IMAGE_TAG_SUFFIX
-  value: "-latest"
-- name: SOURCE_GIT_URL
+- name: SUFFIX
+  description: A suffix appended to all objects
+- name: VERSION
+  description: The major and minor version of this image.
   required: true
+- name: SOURCE_GIT_URL
+  description: Source Git URL
   value: https://github.com/BCDevOps/ha-tomcat9.git
+  required: true
 - name: SOURCE_GIT_REF
-  required: false
+  description: Source Git Branch
   value: master
+  required: true


### PR DESCRIPTION
Built on top of Clecio's improved-configuration work.
Does not implement the environment variable for enabling/disabling session replication.

Opinionated pieces:
- having separate image and buildstream suffixes is low-value; simplify the process by using one suffix for both.
- having a default suffix of 'build' means developers might clobber each others' work; mandate the parameter, but do not supply it.